### PR TITLE
Fixes for Safari compatibility

### DIFF
--- a/src/js/settings/Colors.js
+++ b/src/js/settings/Colors.js
@@ -16,9 +16,11 @@ const palette195741 = [
 
 const palette = palette195741;
 
-export default class Colors {
-  static background = palette[0];
-  static obstacles = palette[1];
-  static enemies = palette[2];
-  static player = palette[3];
+const Colors = {
+  background: palette[0],
+  obstacles: palette[1],
+  enemies: palette[2],
+  player: palette[3],
 }
+
+export default Colors;

--- a/src/js/sound/ZzFx.js
+++ b/src/js/sound/ZzFx.js
@@ -14,6 +14,7 @@ import { volume as zzfxV } from '../settings/volume'
 const zzfxR = 44100 // sample rate
 
 export default function zzfxInit() {
+  var AudioContext = window.AudioContext || window.webkitAudioContext;
   const zzfxX = new AudioContext()
 
   // ZzFXMicro - Zuper Zmall Zound Zynth


### PR DESCRIPTION
The game submitted to the competition doesn't work on Safari, but this PR will fix it.

# Details

Safari doesn't support static fields yet, and generated syntax errors in the `Colors` class.

Safari also implements the draft AudioContext API with vendor-specific prefix "webkit".